### PR TITLE
Prevent up/down arrows from stepping number inputs

### DIFF
--- a/src/arrow-table.js
+++ b/src/arrow-table.js
@@ -153,6 +153,7 @@
 					}, this.options.continuousDelay);
 				}
 
+				event.preventDefault();
 				this.move(event.target, direction);
 			};
 


### PR DESCRIPTION
Up and down arrow keys, in the current codebase, will increment the value of the input by the step value. A simple `preventDefault()` fixes that. 

I made changes to the src file but am too dumb to figure out how to build them into dist 😆 